### PR TITLE
Place all recent changes in new versioned indexes, keeping the old ones

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -80,24 +80,24 @@ global_mappings:
 
 # For each index alias, what are the versioned index names for the latest versions of each?
 latest_versions:
-  narrative: "narrative_2"
-  reads: "reads_2"
-  assembly: "assembly_2"
-  genome: "genome_2"
-  genome_features: "genome_features_3"
+  narrative: "narrative_1"
+  reads: "reads_1"
+  assembly: "assembly_1"
+  genome: "genome_1"
+  genome_features: "genome_features_2"
   pangenome: "pangenome_1"
   pangenome_orthologfamily: "pangenome_orthologfamily_1"
-  taxon: "taxon_2"
+  taxon: "taxon_1"
   tree: "tree_1"
   matrix: "matrix_1"
   attribute_mapping: "attribute_ma pping_1"
   genomeset: "genomeset_1"
   indexing_errors: "indexing_errors_1"
   indexer_messages: "indexer_messages_1"
-  annotated_metagenome_assembly: "annotated_metagenome_assembly_2"
-  annotated_metagenome_assembly_features: "annotated_metagenome_assembly_features_2"
-  annotated_metagenome_assembly_version: "annotated_metagenome_assembly_version_2"
-  annotated_metagenome_assembly_features_version: "annotated_metagenome_assembly_features_version_2"
+  annotated_metagenome_assembly: "annotated_metagenome_assembly_1"
+  annotated_metagenome_assembly_features: "annotated_metagenome_assembly_features_1"
+  annotated_metagenome_assembly_version: "annotated_metagenome_assembly_version_1"
+  annotated_metagenome_assembly_features_version: "annotated_metagenome_assembly_features_version_1"
 
 # Map from unversioned alias to versioned indexes
 aliases:

--- a/config.yaml
+++ b/config.yaml
@@ -102,42 +102,36 @@ latest_versions:
 # Map from unversioned alias to versioned indexes
 aliases:
   default_search:
-    - "narrative_2"
-    - "reads_2"
-    - "assembly_2"
-    - "genome_2"
+    - "narrative_1"
+    - "reads_1"
+    - "assembly_1"
+    - "genome_1"
     - "pangenome_1"
     - "pangenome_orthologfamily_1"
-    - "taxon_2"
+    - "taxon_1"
     - "tree_1"
     - "matrix_1"
     - "attribute_mapping_1"
     - "genomeset_1"
     - "indexing_errors_1"
     - "indexer_messages_1"
-    - "annotated_metagenome_assembly_2"
-    - "annotated_metagenome_assembly_features_2"
+    - "annotated_metagenome_assembly_1"
+    - "annotated_metagenome_assembly_features_1"
   narrative:
-    - "narrative_2"
     - "narrative_1"
   reads:
-    - "reads_2"
     - "reads_1"
   assembly:
-    - "assembly_2"
     - "assembly_1"
   genome:
-    - "genome_2"
     - "genome_1"
   genome_features:
-    - "genome_features_3"
     - "genome_features_2"
   pangenome:
     - "pangenome_1"
   pangenome_orthologfamily:
     - "pangenome_orthologfamily_1"
   taxon:
-    - "taxon_2"
     - "taxon_1"
   tree:
     - "tree_1"
@@ -152,16 +146,12 @@ aliases:
   indexer_messages:
     - "indexer_messages_1"
   annotated_metagenome_assembly:
-    - "annotated_metagenome_assembly_2"
     - "annotated_metagenome_assembly_1"
   annotated_metagenome_assembly_features:
-    - "annotated_metagenome_assembly_features_2"
     - "annotated_metagenome_assembly_features_1"
   annotated_metagenome_assembly_version:
-    - "annotated_metagenome_assembly_version_2"
     - "annotated_metagenome_assembly_version_1"
   annotated_metagenome_assembly_features_version:
-    - "annotated_metagenome_assembly_features_version_2"
     - "annotated_metagenome_assembly_features_version_1"
 
 # All ES type mappings

--- a/config.yaml
+++ b/config.yaml
@@ -80,58 +80,64 @@ global_mappings:
 
 # For each index alias, what are the versioned index names for the latest versions of each?
 latest_versions:
-  narrative: "narrative_1"
-  reads: "reads_1"
-  assembly: "assembly_1"
-  genome: "genome_1"
-  genome_features: "genome_features_2"
+  narrative: "narrative_2"
+  reads: "reads_2"
+  assembly: "assembly_2"
+  genome: "genome_2"
+  genome_features: "genome_features_3"
   pangenome: "pangenome_1"
   pangenome_orthologfamily: "pangenome_orthologfamily_1"
-  taxon: "taxon_1"
+  taxon: "taxon_2"
   tree: "tree_1"
   matrix: "matrix_1"
   attribute_mapping: "attribute_ma pping_1"
   genomeset: "genomeset_1"
   indexing_errors: "indexing_errors_1"
   indexer_messages: "indexer_messages_1"
-  annotated_metagenome_assembly: "annotated_metagenome_assembly_1"
-  annotated_metagenome_assembly_features: "annotated_metagenome_assembly_features_1"
-  annotated_metagenome_assembly_version: "annotated_metagenome_assembly_version_1"
-  annotated_metagenome_assembly_features_version: "annotated_metagenome_assembly_features_version_1"
+  annotated_metagenome_assembly: "annotated_metagenome_assembly_2"
+  annotated_metagenome_assembly_features: "annotated_metagenome_assembly_features_2"
+  annotated_metagenome_assembly_version: "annotated_metagenome_assembly_version_2"
+  annotated_metagenome_assembly_features_version: "annotated_metagenome_assembly_features_version_2"
 
 # Map from unversioned alias to versioned indexes
 aliases:
   default_search:
-    - "narrative_1"
-    - "reads_1"
-    - "assembly_1"
-    - "genome_1"
+    - "narrative_2"
+    - "reads_2"
+    - "assembly_2"
+    - "genome_2"
     - "pangenome_1"
     - "pangenome_orthologfamily_1"
-    - "taxon_1"
+    - "taxon_2"
     - "tree_1"
     - "matrix_1"
     - "attribute_mapping_1"
     - "genomeset_1"
     - "indexing_errors_1"
     - "indexer_messages_1"
-    - "annotated_metagenome_assembly_1"
-    - "annotated_metagenome_assembly_features_1"
+    - "annotated_metagenome_assembly_2"
+    - "annotated_metagenome_assembly_features_2"
   narrative:
+    - "narrative_2"
     - "narrative_1"
   reads:
+    - "reads_2"
     - "reads_1"
   assembly:
+    - "assembly_2"
     - "assembly_1"
   genome:
+    - "genome_2"
     - "genome_1"
   genome_features:
+    - "genome_features_3"
     - "genome_features_2"
   pangenome:
     - "pangenome_1"
   pangenome_orthologfamily:
     - "pangenome_orthologfamily_1"
   taxon:
+    - "taxon_2"
     - "taxon_1"
   tree:
     - "tree_1"
@@ -146,17 +152,38 @@ aliases:
   indexer_messages:
     - "indexer_messages_1"
   annotated_metagenome_assembly:
+    - "annotated_metagenome_assembly_2"
     - "annotated_metagenome_assembly_1"
   annotated_metagenome_assembly_features:
+    - "annotated_metagenome_assembly_features_2"
     - "annotated_metagenome_assembly_features_1"
   annotated_metagenome_assembly_version:
+    - "annotated_metagenome_assembly_version_2"
     - "annotated_metagenome_assembly_version_1"
   annotated_metagenome_assembly_features_version:
+    - "annotated_metagenome_assembly_features_version_2"
     - "annotated_metagenome_assembly_features_version_1"
 
 # All ES type mappings
 mappings:
+
   "narrative_1":
+    global_mappings: [ws_auth, ws_object]
+    properties:
+      narrative_title: {type: text, copy_to: agg_fields}
+      data_objects:
+        type: nested
+        properties:
+          name: {type: keyword, copy_to: agg_fields}
+          obj_type: {type: keyword, copy_to: agg_fields}
+      cells:
+        type: object
+        properties:
+          desc: {type: text, copy_to: agg_fields}
+          cell_type: {type: keyword}
+      total_cells: {type: short}
+
+  "narrative_2":
     global_mappings: [ws_auth, ws_object]
     properties:
       narrative_title:
@@ -185,6 +212,19 @@ mappings:
     global_mappings: [ws_auth, ws_object]
     properties:
       sequencing_tech: {type: keyword, copy_to: agg_fields}
+      size: {type: integer}
+      interleaved: {type: boolean}
+      single_genome: {type: boolean}
+      provenance_services: {type: keyword}
+      phred_type: {type: text}
+      gc_content: {type: float}
+      mean_quality_score: {type: float}
+      mean_read_length: {type: float}
+
+  "reads_2":
+    global_mappings: [ws_auth, ws_object]
+    properties:
+      sequencing_tech: {type: keyword, copy_to: agg_fields}
       size: {type: long}
       interleaved: {type: boolean}
       single_genome: {type: boolean}
@@ -203,6 +243,22 @@ mappings:
       percent_circle_contigs: {type: float}
       assembly_id: {type: keyword}
       gc_content: {type: float}
+      size: {type: integer}
+      num_contigs: {type: integer}
+      taxon_ref: {type: keyword}
+      external_origination_date: {type: keyword}  # should maybe be of type date?
+      external_source_id: {type: keyword}
+      external_source: {type: keyword}
+
+  "assembly_2":
+    global_mappings: [ws_auth, ws_object]
+    properties:
+      assembly_name: {type: keyword, copy_to: agg_fields}
+      mean_contig_length: {type: float}
+      percent_complete_contigs: {type: float}
+      percent_circle_contigs: {type: float}
+      assembly_id: {type: keyword}
+      gc_content: {type: float}
       size: {type: long}
       num_contigs: {type: integer}
       taxon_ref: {type: keyword}
@@ -211,6 +267,30 @@ mappings:
       external_source: {type: keyword}
 
   "genome_1":
+    global_mappings: [ws_auth, ws_object]
+    properties:
+      genome_id: {type: keyword}
+      scientific_name: {type: keyword, copy_to: agg_fields}
+      size: {type: integer}
+      num_contigs: {type: integer}
+      genome_type: {type: keyword, copy_to: agg_fields}
+      gc_content: {type: float}
+      taxonomy: {type: keyword, copy_to: agg_fields}
+      mean_contig_length: {type: float}
+      external_origination_date: {type: keyword}  # should maybe be of type date?
+      original_source_file_name: {type: keyword}
+      # new fields to include:
+      cds_count: {type: integer}
+      feature_count: {type: integer}
+      mrna_count: {type: integer}
+      non_coding_feature_count: {type: integer}
+      assembly_ref: {type: keyword, copy_to: agg_fields}
+      source_id: {type: keyword}
+      feature_counts: {type: object}
+      source: {type: keyword, copy_to: agg_fields}
+      warnings: {type: text}
+
+  "genome_2":
     global_mappings: [ws_auth, ws_object]
     properties:
       genome_id: {type: keyword}
@@ -249,6 +329,23 @@ mappings:
     global_mappings: [ws_subobject, ws_auth, ws_object]
     properties:
       id: {type: keyword}
+      genome_scientific_name: {type: keyword, copy_to: agg_fields}
+      feature_type: {type: keyword, copy_to: agg_fields}
+      functions: {type: keyword, copy_to: agg_fields}
+      contig_ids: {type: keyword, copy_to: agg_fields}
+      sequence_length: {type: integer}
+      genome_version: {type: integer}
+      assembly_ref: {type: keyword, copy_to: agg_fields}
+      genome_feature_type: {type: keyword}
+      starts: {type: integer}
+      strands: {type: keyword}
+      stops: {type: integer}
+      aliases: {type: keyword, copy_to: agg_fields}
+
+  "genome_features_3":
+    global_mappings: [ws_subobject, ws_auth, ws_object]
+    properties:
+      id: {type: keyword}
       genome_scientific_name:
         type: text
         copy_to: agg_fields
@@ -284,6 +381,17 @@ mappings:
       gene_ids: {type: keyword}
 
   "taxon_1":
+    global_mappings: [ws_auth, ws_object]
+    properties:
+      scientific_name: {type: keyword, copy_to: agg_fields}
+      scientific_lineage: {type: keyword, copy_to: agg_fields}
+      domain: {type: keyword, copy_to: agg_fields}
+      kingdom: {type: keyword, copy_to: agg_fields}
+      parent_taxon_ref: {type: keyword}
+      genetic_code: {type: integer}
+      aliases: {type: keyword, copy_to: agg_fields}
+
+  "taxon_2":
     global_mappings: [ws_auth, ws_object]
     properties:
       scientific_name:
@@ -352,6 +460,26 @@ mappings:
   "annotated_metagenome_assembly_1":
     global_mappings: [ws_auth, ws_object]
     properties:
+      size: {type: integer}
+      source_id: {type: keyword}
+      source: {type: keyword, copy_to: agg_fields}
+      gc_content: {type: float}
+      warnings: {type: text}
+      num_contigs: {type: integer}
+      mean_contig_length: {type: float}
+      external_source_origination_date: {type: keyword}
+      original_source_file_name: {type: keyword}
+      environment: {type: keyword}
+      num_features: {type: integer}
+      publication_authors: {type: keyword, copy_to: agg_fields}
+      publication_titles: {type: keyword, copy_to: agg_fields}
+      molecule_type: {type: keyword}
+      assembly_ref: {type: keyword}
+      notes: {type: text, copy_to: agg_fields}
+
+  "annotated_metagenome_assembly_2":
+    global_mappings: [ws_auth, ws_object]
+    properties:
       size: {type: long}
       source_id: {type: keyword}
       source: {type: keyword, copy_to: agg_fields}
@@ -370,6 +498,28 @@ mappings:
       notes: {type: text, copy_to: agg_fields}
 
   "annotated_metagenome_assembly_features_1":
+    global_mappings: [ws_subobject, ws_auth, ws_object]
+    properties:
+      id: {type: keyword}
+      type: {type: keyword, copy_to: agg_fields}
+      size: {type: integer}
+      contig_ids: {type: keyword, copy_to: agg_fields}
+      starts: {type: integer}
+      strands: {type: keyword}
+      stops: {type: integer}
+      functions: {type: text}
+      functional_descriptions: {type: text}
+      warnings: {type: text}
+      parent_gene: {type: keyword}
+      inference_data: {type: keyword}
+      dna_sequence: {type: keyword}
+      gc_content: {type: float}
+      annotated_metagenome_assembly_size: {type: integer}
+      annotated_metagenome_assembly_num_features: {type: integer}
+      annotated_metagenome_assembly_num_contigs: {type: integer}
+      annotated_metagenome_assembly_gc_content: {type: float}
+
+  "annotated_metagenome_assembly_features_2":
     global_mappings: [ws_subobject, ws_auth, ws_object]
     properties:
       id: {type: keyword}
@@ -394,6 +544,26 @@ mappings:
   "annotated_metagenome_assembly_version_1":
     global_mappings: [ws_auth, ws_object]
     properties:
+      size: {type: integer}
+      source_id: {type: keyword}
+      source: {type: keyword, copy_to: agg_fields}
+      gc_content: {type: float}
+      warnings: {type: text}
+      num_contigs: {type: integer}
+      mean_contig_length: {type: float}
+      external_source_origination_date: {type: keyword}
+      original_source_file_name: {type: keyword}
+      environment: {type: keyword}
+      num_features: {type: integer}
+      publication_authors: {type: keyword, copy_to: agg_fields}
+      publication_titles: {type: keyword, copy_to: agg_fields}
+      molecule_type: {type: keyword}
+      assembly_ref: {type: keyword}
+      notes: {type: text, copy_to: agg_fields}
+
+  "annotated_metagenome_assembly_version_2":
+    global_mappings: [ws_auth, ws_object]
+    properties:
       size: {type: long}
       source_id: {type: keyword}
       source: {type: keyword, copy_to: agg_fields}
@@ -412,6 +582,28 @@ mappings:
       notes: {type: text, copy_to: agg_fields}
 
   "annotated_metagenome_assembly_features_version_1":
+    global_mappings: [ws_subobject, ws_auth, ws_object]
+    properties:
+      id: {type: keyword}
+      type: {type: keyword, copy_to: agg_fields}
+      size: {type: integer}
+      contig_ids: {type: keyword, copy_to: agg_fields}
+      starts: {type: integer}
+      strands: {type: keyword}
+      stops: {type: integer}
+      functions: {type: text, copy_to: agg_fields}
+      functional_descriptions: {type: text, copy_to: agg_fields}
+      warnings: {type: text}
+      parent_gene: {type: keyword}
+      inference_data: {type: keyword}
+      dna_sequence: {type: keyword}
+      gc_content: {type: float}
+      annotated_metagenome_assembly_size: {type: integer}
+      annotated_metagenome_assembly_num_features: {type: integer}
+      annotated_metagenome_assembly_num_contigs: {type: integer}
+      annotated_metagenome_assembly_gc_content: {type: float}
+
+  "annotated_metagenome_assembly_features_version_2":
     global_mappings: [ws_subobject, ws_auth, ws_object]
     properties:
       id: {type: keyword}
@@ -440,7 +632,7 @@ mappings:
       objid: {type: integer}
       error: {type: text}
 
-  indexer_messages_1:
+  "indexer_messages_1":
     properties:
       user: {type: keyword}
       wsid: {type: integer}


### PR DESCRIPTION
We'll first create these new indexes and use the reindex api on elasticsearch to copy data over from the previous indexes. I'll also reindex narratives from scratch, but not genomes for now.

When we're sure that any search clients (including index runner) will still work with the new indexes, then I we can remove the older type mappings, update the aliases, and delete the old type mappings.

cc @eapearson -- I would add you as reviewer here, but you don't get listed for some reason.